### PR TITLE
Driver platform + Major interface changement

### DIFF
--- a/src/pza_drv_std_interfaces/__init__.py
+++ b/src/pza_drv_std_interfaces/__init__.py
@@ -1,8 +1,10 @@
 from .driver_fake_io import DriverFakeIo
 from .driver_std_serial import DriverStdSerial
 from .driver_sys_class_gpio import DriverSysClassGpio
+from .driver_platform import DriverPlatform
 
 PZA_DRIVERS_LIST=[
+    DriverPlatform,
     DriverFakeIo,
     DriverStdSerial,
     DriverSysClassGpio

--- a/src/pza_drv_std_interfaces/driver_platform.py
+++ b/src/pza_drv_std_interfaces/driver_platform.py
@@ -1,0 +1,42 @@
+import time
+import json
+from loguru import logger
+from pza_platform import MetaDriver
+
+class DriverPlatform(MetaDriver):
+    
+    ###########################################################################
+    ###########################################################################
+
+    def config(self):
+        """ From MetaDriver
+        """
+        return {
+            "compatible": "platform_py",
+            "info": { "type": "platform", "version": "1.0" }
+        }
+
+    ###########################################################################
+    ###########################################################################
+
+    def setup(self, tree):
+        """ From MetaDriver
+        """
+        # Push the tree config
+        self.push_attribute("tree", json.dumps(self.platform.tree), retain=True)
+
+        # 
+        driver_configs = []
+        for drv in self.platform.drivers:
+            driver_configs.append(drv().config())
+        self.push_attribute("drivers", json.dumps(driver_configs), retain=True)
+
+
+    ###########################################################################
+    ###########################################################################
+
+    def loop(self):
+        """ From MetaDriver
+        """
+        return False
+

--- a/src/pza_drv_std_interfaces/driver_platform.py
+++ b/src/pza_drv_std_interfaces/driver_platform.py
@@ -22,6 +22,14 @@ class DriverPlatform(MetaDriver):
     def setup(self, tree):
         """ From MetaDriver
         """
+        pass
+
+    ###########################################################################
+    ###########################################################################
+
+    def on_start(self):
+        """ From MetaDriver
+        """
         # Push the tree config
         self.push_attribute("tree", json.dumps(self.platform.tree), retain=True)
 

--- a/src/pza_platform/meta_driver.py
+++ b/src/pza_platform/meta_driver.py
@@ -96,10 +96,10 @@ class MetaDriver(metaclass=abc.ABCMeta):
             self.mqtt_client.loop_start()
 
             #
-            self.setup(self.tree)
+            self.__load_commands()
 
             #
-            self.__load_commands()
+            self.on_start()
 
             # Main loop
             self.log.debug("Interface started...")
@@ -192,6 +192,14 @@ class MetaDriver(metaclass=abc.ABCMeta):
     ###########################################################################
     ###########################################################################
 
+    def initial_setup(self):
+        """To ease the interface initialisation
+        """
+        self.setup(self.tree)
+
+    ###########################################################################
+    ###########################################################################
+
     @abc.abstractmethod
     def config(self):
         """
@@ -203,6 +211,17 @@ class MetaDriver(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def setup(self, tree):
+        """Mono-threaded initialization of the interface
+
+        Warning mqtt client is not initialized at this step
+        """
+        pass
+
+    ###########################################################################
+    ###########################################################################
+
+    # @abc.abstractmethod
+    def on_start(self):
         """
         """
         pass

--- a/src/pza_platform/meta_driver.py
+++ b/src/pza_platform/meta_driver.py
@@ -23,13 +23,13 @@ class MetaDriver(metaclass=abc.ABCMeta):
     ###########################################################################
     ###########################################################################
 
-    def initialize(self, server, machine, broker, tree):
+    def initialize(self, platform, machine, broker, tree):
         """
         """
         #  \todo assert if info not present
         #  \todo assert if name not present
 
-        self.server = server
+        self.platform = platform
         self.machine = machine
         self.broker = broker
         self.tree = tree
@@ -187,7 +187,7 @@ class MetaDriver(metaclass=abc.ABCMeta):
     def get_interface_instance_from_name(self, name):
         """
         """
-        return self.server.get_interface_instance_from_name(name)
+        return self.platform.get_interface_instance_from_name(name)
 
     ###########################################################################
     ###########################################################################

--- a/src/pza_platform/meta_platform.py
+++ b/src/pza_platform/meta_platform.py
@@ -103,8 +103,23 @@ class MetaPlatform:
     ###########################################################################
 
     def __interpret_interface_declaration(self, machine, broker, interface_declaration):
+        """ Interpret option in the interface declaration
+
+        Options are
+        - disable: to prevent this interface from beeing loaded
+        - repeated: to execute the interface loading multiple times
         """
-        """
+        # Check if the interface is disabled by the user
+        if "disable" in interface_declaration and interface_declaration["disable"] == True:
+            name = "?"
+            if "name" in interface_declaration:
+                name = interface_declaration["name"]
+            driver_name = "?"
+            if "driver" in interface_declaration:
+                driver_name = interface_declaration["driver"]
+            logger.warning("> {} [{}] interface disabled", name, driver_name)
+            return
+
         # Multiple interfaces, need to create one interface for each
         if "repeated" in interface_declaration:
             for param in interface_declaration["repeated"]:
@@ -114,7 +129,6 @@ class MetaPlatform:
         # Only one interface to start
         else:
             self.__load_interface(machine, broker, interface_declaration)
-
 
     ###########################################################################
     ###########################################################################

--- a/src/pza_platform/meta_platform.py
+++ b/src/pza_platform/meta_platform.py
@@ -10,7 +10,7 @@ from sys import platform
 
 
 class MetaPlatform:
-    """ Main class to manage the server
+    """ Main class to manage the platform
     """
 
     ###########################################################################
@@ -37,7 +37,7 @@ class MetaPlatform:
         """
         """
         # Manage arguments
-        parser = argparse.ArgumentParser(description='Manage Panduza Server')
+        parser = argparse.ArgumentParser(description='Manage Panduza Platform')
         parser.add_argument('-t', '--tree', help='path to the panduza tree (*.json)', metavar="FILE")
         parser.add_argument('-l', '--log', dest='enable_logs', action='store_true', help='start the logs')
         args = parser.parse_args()
@@ -62,19 +62,21 @@ class MetaPlatform:
     ###########################################################################
     ###########################################################################
 
-    def __load_broker(self, machine, broker_name, broker_tree):
+    def __load_tree_broker(self, machine, broker_name, broker_tree):
+        """ Load interfaces declared in the tree for the given broker
         """
-        """
-        #
+        # Debug log
         logger.info(" + {} ({}:{})", broker_name, broker_tree["addr"], broker_tree["port"])
 
-        #
+        # Create broker object
         broker = Broker(broker_tree["addr"], broker_tree["port"])
 
-        #
+        # For each interface create it
         for interface in broker_tree["interfaces"]:
             self.__interpret_interface_declaration(machine, broker, interface)
 
+        # At last start a platform driver for this broker
+        self.__load_interface(machine, broker, { "name": "platform", "driver": "platform_py" })
 
     ###########################################################################
     ###########################################################################
@@ -112,6 +114,7 @@ class MetaPlatform:
         # Only one interface to start
         else:
             self.__load_interface(machine, broker, interface_declaration)
+
 
     ###########################################################################
     ###########################################################################
@@ -199,7 +202,7 @@ class MetaPlatform:
     ###########################################################################
 
     def run(self):
-        """Run the server
+        """Run the platform
         """
 
         try:
@@ -209,7 +212,7 @@ class MetaPlatform:
             # Parse configs
             logger.debug("load tree:{}", json.dumps(self.tree, indent=1))
             for broker in self.tree["brokers"]:
-                self.__load_broker(self.tree["machine"], broker, self.tree["brokers"][broker])
+                self.__load_tree_broker(self.tree["machine"], broker, self.tree["brokers"][broker])
 
             # Run all the interfaces
             for interface in self.interfaces:
@@ -233,7 +236,7 @@ class MetaPlatform:
 
     def stop(self):
         """
-        To stop the server
+        To stop the platform
         """
         # Request a stop for each driver
         for interface in self.interfaces:

--- a/src/pza_platform/meta_platform.py
+++ b/src/pza_platform/meta_platform.py
@@ -228,7 +228,11 @@ class MetaPlatform:
             for broker in self.tree["brokers"]:
                 self.__load_tree_broker(self.tree["machine"], broker, self.tree["brokers"][broker])
 
-            # Run all the interfaces
+            # Setup all the interfaces in the same thread
+            for interface in self.interfaces:
+                interface["instance"].initial_setup()
+
+            # Run all the interfaces on differents threads
             for interface in self.interfaces:
                 t = threading.Thread(target=interface["instance"].start)
                 self.threads.append(t)


### PR DESCRIPTION
Driver platform create a topic to list the tree and available drivers on the platform. Reason: futur creation of the webapp widget to manage the platform.

:warning: It can brake some driver
I did an new event on driver 'on_start' to trigger action when mqtt client is ready. Now setup is monothreaded but does not allow mqtt usage. The reason is to avoid to force user to create very complexe intialization state machine.
:warning: 


